### PR TITLE
support for i64 integers

### DIFF
--- a/redisql_lib/src/sqlite.rs
+++ b/redisql_lib/src/sqlite.rs
@@ -184,7 +184,7 @@ pub enum EntityType {
 
 // TODO XXX explore it is possible to change these String into &str
 pub enum Entity {
-    Integer { int: i32 },
+    Integer { int: i64 },
     Float { float: f64 },
     Text { text: String },
     Blob { blob: String },
@@ -199,7 +199,7 @@ impl Entity {
         match get_entity_type(stmt.get_raw_stmt(), i) {
             EntityType::Integer => {
                 let int = unsafe {
-                    ffi::sqlite3_column_int(stmt.get_raw_stmt(), i)
+                    ffi::sqlite3_column_int64(stmt.get_raw_stmt(), i)
                 };
                 Entity::Integer { int }
             }
@@ -215,9 +215,8 @@ impl Entity {
                         stmt.get_raw_stmt(),
                         i,
                     )
-                        as *const c_char)
-                        .to_string_lossy()
-                        .into_owned()
+                        as *const c_char).to_string_lossy()
+                    .into_owned()
                 };
                 Entity::Text { text: value }
             }
@@ -228,9 +227,8 @@ impl Entity {
                         stmt.get_raw_stmt(),
                         i,
                     )
-                        as *const c_char)
-                        .to_string_lossy()
-                        .into_owned()
+                        as *const c_char).to_string_lossy()
+                    .into_owned()
                 };
                 Entity::Blob { blob: value }
             }

--- a/test/correctness/test.py
+++ b/test/correctness/test.py
@@ -621,6 +621,25 @@ class TestCopySyncronous(TestRediSQLWithExec):
         result = self.exec_naked("REDISQL.QUERY_STATEMENT", "DB2", "select1")
         self.assertEquals(result, [[1L]])
 
+class TestBigInt(TestRediSQLWithExec):
+    def test_big_int(self):
+        with DB(self, "A"):
+            done = self.exec_naked("REDISQL.EXEC", "A", "CREATE TABLE ip_to_asn(start INT8, end INT8, asn int, hosts int8)")
+            self.assertEquals(done, ["DONE", 0L])
+
+            done = self.exec_naked("REDISQL.EXEC", "A", "insert into ip_to_asn values (2883484276228096000, 2883484280523063295, 265030, 4294967295)")
+            self.assertEquals(done, ["DONE", 1L])
+
+            result = self.exec_naked("REDISQL.EXEC", "A", "SELECT * FROM ip_to_asn;")
+            self.assertEquals(result, [
+                [
+                    2883484276228096000,
+                    2883484280523063295,
+                    265030,
+                    4294967295]
+                ])
+
+
 
 if __name__ == '__main__':
    unittest.main()


### PR DESCRIPTION
Use i64 instead of i32 to store integers.